### PR TITLE
feat: statefulShellBranch supports navigator observers

### DIFF
--- a/packages/go_router_builder/lib/src/route_config.dart
+++ b/packages/go_router_builder/lib/src/route_config.dart
@@ -141,6 +141,7 @@ class StatefulShellBranchConfig extends RouteBaseConfig {
     required this.navigatorKey,
     required super.routeDataClass,
     required super.parent,
+    required this.observers,
     this.restorationScopeId,
     this.initialLocation,
   }) : super._();
@@ -154,6 +155,9 @@ class StatefulShellBranchConfig extends RouteBaseConfig {
   /// The initial route.
   final String? initialLocation;
 
+  /// The navigator observers.
+  final String? observers;
+
   @override
   Iterable<String> classDeclarations() => <String>[];
 
@@ -163,7 +167,8 @@ class StatefulShellBranchConfig extends RouteBaseConfig {
   String get routeConstructorParameters =>
       '${navigatorKey == null ? '' : 'navigatorKey: $navigatorKey,'}'
       '${restorationScopeId == null ? '' : 'restorationScopeId: $restorationScopeId,'}'
-      '${initialLocation == null ? '' : 'initialLocation: $initialLocation,'}';
+      '${initialLocation == null ? '' : 'initialLocation: $initialLocation,'}'
+      '${observers == null ? '' : 'observers: $observers,'}';
 
   @override
   String get routeDataClassName => 'StatefulShellBranchData';
@@ -517,6 +522,10 @@ abstract class RouteBaseConfig {
           initialLocation: _generateParameterGetterCode(
             classElement,
             parameterName: r'$initialLocation',
+          ),
+          observers: _generateParameterGetterCode(
+            classElement,
+            parameterName: r'$observers',
           ),
         );
       case 'TypedGoRoute':


### PR DESCRIPTION
This pr added the ability to provide a list of NavigatorObservers to a StatefulShellBranch. 
The equivalent was never added to go_router_builder, so this pr provides that functionality.

With this change, you can provide NavigatorObservers directly to the StatefulShellBranch

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [ ] I signed the [CLA].
- [ ] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
